### PR TITLE
Flash lfq for percolator (#596)

### DIFF
--- a/MassSpectrometry/MzSpectra/SpectralSimilarity.cs
+++ b/MassSpectrometry/MzSpectra/SpectralSimilarity.cs
@@ -32,7 +32,9 @@ namespace MassSpectrometry.MzSpectra
         public double[] experimentalXArray { get; private set; }
         public double[] theoreticalYArray { get; private set; }
         public double[] theoreticalXArray { get; private set; }
+
         private double localPpmTolerance;
+
         private List<(double, double)> _intensityPairs = new List<(double, double)>();
         
         public List<(double, double)> intensityPairs

--- a/Test/TestSpectralSimilarity.cs
+++ b/Test/TestSpectralSimilarity.cs
@@ -118,10 +118,10 @@ namespace Test
 
             //explore bounds of binary search
             primary = new MzSpectrum(new double[] { 1, 2, 3, 4 }, new double[] { 1, 2, 3, 4 }, false);
-            secondary = new MzSpectrum(new double[] { 1.000009, 1.99999, 3.00004, 3.99995 }, new double[] { 1, 2, 3, 4 }, false);
+            secondary = new MzSpectrum(new double[] { 1.000011, 1.99997, 3.000031, 3.99995 }, new double[] { 1, 2, 3, 4 }, false);
 
             s = new SpectralSimilarity(primary, secondary, SpectralSimilarity.SpectrumNormalizationScheme.spectrumSum, ppmTolerance, true);
-            Assert.AreEqual(6, s.intensityPairs.Count);
+            Assert.AreEqual(8, s.intensityPairs.Count);
 
             //Test alternate constructor
             primary = new MzSpectrum(new double[] { 1, 2, 3 }, new double[] { 2, 4, 6 }, false);

--- a/TestFlashLFQ/TestFlashLFQ.cs
+++ b/TestFlashLFQ/TestFlashLFQ.cs
@@ -84,6 +84,53 @@ namespace Test
         }
 
         [Test]
+        public static void TestFlashLfqWithPercolatorStyleIds()
+        {
+            // get the raw file paths
+            SpectraFileInfo raw = new SpectraFileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", @"sliced-raw.raw"), "a", 0, 0, 0);
+            SpectraFileInfo mzml = new SpectraFileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", @"sliced-mzml.mzml"), "a", 1, 0, 0);
+
+            // create some PSMs
+            var pg = new ProteinGroup("MyProtein", "gene", "org");
+            Identification id1 = new Identification(raw, null, "EGFQVAD[15.99]GPLYR", 1350.65681, 94.12193, 2, new List<ProteinGroup> { pg });
+            Identification id2 = new Identification(raw, null, "EGFQVAD[15.99]GPLYR", 1350.65681, 94.05811, 2, new List<ProteinGroup> { pg });
+            Identification id3 = new Identification(mzml, null, "EGFQVAD[15.99]GPLYR", 1350.65681, 94.12193, 2, new List<ProteinGroup> { pg });
+            Identification id4 = new Identification(mzml, null, "EGFQVAD[15.99]GPLYR", 1350.65681, 94.05811, 2, new List<ProteinGroup> { pg });
+
+            // create the FlashLFQ engine
+            FlashLfqEngine engine = new FlashLfqEngine(new List<Identification> { id1, id2, id3, id4 }, normalize: true, maxThreads: 1);
+
+            // run the engine
+            var results = engine.Run();
+
+            // check raw results
+            Assert.That(results.Peaks[raw].Count == 1);
+            Assert.That(results.Peaks[raw].First().Intensity > 0);
+            Assert.That(!results.Peaks[raw].First().IsMbrPeak);
+            Assert.That(results.PeptideModifiedSequences["EGFQVAD[15.99]GPLYR"].GetIntensity(raw) > 0);
+            Assert.That(results.ProteinGroups["MyProtein"].GetIntensity(raw) > 0);
+
+            // check mzml results
+            Assert.That(results.Peaks[mzml].Count == 1);
+            Assert.That(results.Peaks[mzml].First().Intensity > 0);
+            Assert.That(!results.Peaks[mzml].First().IsMbrPeak);
+            Assert.That(results.PeptideModifiedSequences["EGFQVAD[15.99]GPLYR"].GetIntensity(mzml) > 0);
+            Assert.That(results.ProteinGroups["MyProtein"].GetIntensity(mzml) > 0);
+
+            // check that condition normalization worked
+            int int1 = (int)System.Math.Round(results.Peaks[mzml].First().Intensity, 0);
+            int int2 = (int)System.Math.Round(results.Peaks[raw].First().Intensity, 0);
+            Assert.That(int1 == int2);
+
+            // test peak output
+            results.WriteResults(
+                Path.Combine(TestContext.CurrentContext.TestDirectory, @"peaks.tsv"),
+                Path.Combine(TestContext.CurrentContext.TestDirectory, @"modSeq.tsv"),
+                Path.Combine(TestContext.CurrentContext.TestDirectory, @"protein.tsv"),
+                null,
+                true);
+        }
+        [Test]
         public static void TestEnvelopQuantification()
         {
             Loaders.LoadElements();
@@ -1311,4 +1358,5 @@ namespace Test
             File.Delete(filepath);
         }
     }
+
 }


### PR DESCRIPTION
* correct Within calculation

* update unit tests

* new Identification object with no base sequence

* use averagine for complete chemical formula when sequence is not parsable.

* fixed unit test

* fix merge conflicts

* fix merge conflic

* a

* fix spectral similarity unit test

* deleted extra identification class

Co-authored-by: MICHAEL SHORTREED <mrshortreed@wisc.edu>