### PR TITLE
[WIP]Top down biomarker (#601)

### DIFF
--- a/Proteomics/Protein/Protein.cs
+++ b/Proteomics/Protein/Protein.cs
@@ -1,5 +1,4 @@
-﻿using Proteomics.AminoAcidPolymer;
-using Proteomics.Fragmentation;
+﻿using Proteomics.Fragmentation;
 using Proteomics.ProteolyticDigestion;
 using System;
 using System.Collections.Generic;
@@ -10,6 +9,8 @@ namespace Proteomics
 {
     public class Protein
     {
+        private List<ProteolysisProduct> _proteolysisProducts;
+
         /// <summary>
         /// Protein. Filters out modifications that do not match their amino acid target site.
         /// </summary>
@@ -48,7 +49,7 @@ namespace Proteomics
             SampleNameForVariants = sampleNameForVariants;
 
             GeneNames = geneNames ?? new List<Tuple<string, string>>();
-            ProteolysisProducts = proteolysisProducts ?? new List<ProteolysisProduct>();
+            _proteolysisProducts = proteolysisProducts ?? new List<ProteolysisProduct>();
             SequenceVariations = sequenceVariations ?? new List<SequenceVariation>();
             AppliedSequenceVariations = appliedSequenceVariations ?? new List<SequenceVariation>();
             OriginalNonVariantModifications = oneBasedModifications ?? new Dictionary<int, List<Modification>>();
@@ -85,7 +86,7 @@ namespace Proteomics
             DatabaseFilePath = originalProtein.DatabaseFilePath;
             SampleNameForVariants = originalProtein.SampleNameForVariants;
             GeneNames = originalProtein.GeneNames;
-            ProteolysisProducts = originalProtein.ProteolysisProducts;
+            _proteolysisProducts = originalProtein._proteolysisProducts;
             SequenceVariations = originalProtein.SequenceVariations;
             AppliedSequenceVariations = originalProtein.AppliedSequenceVariations;
             OriginalNonVariantModifications = originalProtein.OriginalNonVariantModifications;
@@ -154,8 +155,11 @@ namespace Proteomics
         public IEnumerable<SequenceVariation> SequenceVariations { get; }
         public IEnumerable<DisulfideBond> DisulfideBonds { get; }
         public IEnumerable<SpliceSite> SpliceSites { get; }
+
         //TODO: Generate all the proteolytic products as distinct proteins during XML reading and delete the ProteolysisProducts parameter
-        public IEnumerable<ProteolysisProduct> ProteolysisProducts { get; }
+        public IEnumerable<ProteolysisProduct> ProteolysisProducts
+        { get { return _proteolysisProducts; } }
+
         public IEnumerable<DatabaseReference> DatabaseReferences { get; }
         public string DatabaseFilePath { get; }
 
@@ -229,28 +233,30 @@ namespace Proteomics
         /// </summary>
         public IEnumerable<PeptideWithSetModifications> Digest(DigestionParams digestionParams, List<Modification> allKnownFixedModifications,
             List<Modification> variableModifications, List<SilacLabel> silacLabels = null, (SilacLabel startLabel, SilacLabel endLabel)? turnoverLabels = null)
-        {            
+        {
             //can't be null
-            allKnownFixedModifications = allKnownFixedModifications ?? new List<Modification>(); 
+            allKnownFixedModifications = allKnownFixedModifications ?? new List<Modification>();
             // add in any modifications that are caused by protease digestion
-            if (digestionParams.Protease.CleavageMod!= null && !allKnownFixedModifications.Contains(digestionParams.Protease.CleavageMod))
+            if (digestionParams.Protease.CleavageMod != null && !allKnownFixedModifications.Contains(digestionParams.Protease.CleavageMod))
             {
-                allKnownFixedModifications.Add(digestionParams.Protease.CleavageMod);                
-            }                      
+                allKnownFixedModifications.Add(digestionParams.Protease.CleavageMod);
+            }
             variableModifications = variableModifications ?? new List<Modification>();
             CleavageSpecificity searchModeType = digestionParams.SearchModeType;
 
             ProteinDigestion digestion = new ProteinDigestion(digestionParams, allKnownFixedModifications, variableModifications);
+
             IEnumerable<ProteolyticPeptide> unmodifiedPeptides =
+                digestionParams.Protease.Name == "top-down biomarker" ?
+                digestion.Digestion(this) :
                 searchModeType == CleavageSpecificity.Semi ?
                 digestion.SpeedySemiSpecificDigestion(this) :
-                digestion.Digestion(this);
-            
+                    digestion.Digestion(this);
+
             if (digestionParams.KeepNGlycopeptide || digestionParams.KeepOGlycopeptide)
             {
                 unmodifiedPeptides = GetGlycoPeptides(unmodifiedPeptides, digestionParams.KeepNGlycopeptide, digestionParams.KeepOGlycopeptide);
             }
-            
 
             IEnumerable<PeptideWithSetModifications> modifiedPeptides = unmodifiedPeptides.SelectMany(peptide => peptide.GetModifiedPeptides(allKnownFixedModifications, digestionParams, variableModifications));
 
@@ -265,8 +271,8 @@ namespace Proteomics
             //add silac labels (if needed)
             if (silacLabels != null)
             {
-               return GetSilacPeptides(modifiedPeptides, silacLabels, digestionParams.GeneratehUnlabeledProteinsForSilac, turnoverLabels);
-            }           
+                return GetSilacPeptides(modifiedPeptides, silacLabels, digestionParams.GeneratehUnlabeledProteinsForSilac, turnoverLabels);
+            }
 
             return modifiedPeptides;
         }
@@ -287,7 +293,7 @@ namespace Proteomics
                 }
             }
         }
-       
+
         /// <summary>
         /// Add additional peptides with SILAC amino acids
         /// </summary>
@@ -343,8 +349,8 @@ namespace Proteomics
                         originalLabels.AddRange(startLabel.AdditionalLabels);
                     }
                     SilacLabel startLabelWithSharedOriginalAminoAcid = originalLabels.Where(x => x.OriginalAminoAcid == endLabel.OriginalAminoAcid).FirstOrDefault();
-                    SilacLabel updatedEndLabel = startLabelWithSharedOriginalAminoAcid == null ? 
-                        endLabel : 
+                    SilacLabel updatedEndLabel = startLabelWithSharedOriginalAminoAcid == null ?
+                        endLabel :
                         new SilacLabel(startLabelWithSharedOriginalAminoAcid.AminoAcidLabel, endLabel.AminoAcidLabel, endLabel.LabelChemicalFormula, endLabel.ConvertMassDifferenceToDouble());
                     if (endLabel.AdditionalLabels != null)
                     {
@@ -359,12 +365,12 @@ namespace Proteomics
                     }
 
                     //double check that all labeled amino acids can become unlabeled/relabeled
-                    if(startLabel.AdditionalLabels!=null)
+                    if (startLabel.AdditionalLabels != null)
                     {
-                        foreach(SilacLabel originalLabel in originalLabels)
+                        foreach (SilacLabel originalLabel in originalLabels)
                         {
-                            if(updatedEndLabel.OriginalAminoAcid!= originalLabel.AminoAcidLabel && 
-                                (updatedEndLabel.AdditionalLabels==null || !updatedEndLabel.AdditionalLabels.Any(x=>x.OriginalAminoAcid == originalLabel.AminoAcidLabel)))
+                            if (updatedEndLabel.OriginalAminoAcid != originalLabel.AminoAcidLabel &&
+                                (updatedEndLabel.AdditionalLabels == null || !updatedEndLabel.AdditionalLabels.Any(x => x.OriginalAminoAcid == originalLabel.AminoAcidLabel)))
                             {
                                 updatedEndLabel.AddAdditionalSilacLabel(new SilacLabel(originalLabel.AminoAcidLabel, originalLabel.OriginalAminoAcid, originalLabel.LabelChemicalFormula, originalLabel.ConvertMassDifferenceToDouble()));
                             }
@@ -384,7 +390,7 @@ namespace Proteomics
 
                 Protein silacEndProtein = GenerateFullyLabeledSilacProtein(label);
 
-                //add all peptides containing any label (may also contain unlabeled) 
+                //add all peptides containing any label (may also contain unlabeled)
                 if (label.AdditionalLabels == null) //if there's only one (which is common)
                 {
                     //get the residues to change
@@ -494,7 +500,7 @@ namespace Proteomics
             {
                 bool yielded = false;
                 if (keepNGlycopeptide)
-                {                   
+                {
                     if (rgx.IsMatch(pwsm.BaseSequence))
                     {
                         yielded = true;
@@ -509,7 +515,6 @@ namespace Proteomics
                         yield return pwsm;
                     }
                 }
-                
             }
         }
 
@@ -578,6 +583,65 @@ namespace Proteomics
                 }
             }
             return validModDictionary;
+        }
+
+        public void AddBiomarkersToProteolysisProducts(int fullProteinOneBasedBegin, int fullProteinOneBasedEnd, bool addNterminalDigestionBiomarkers, bool addCterminalDigestionBiomarkers, bool retainNterminalMethionine, int minProductBaseSequenceLength, int lengthOfProteolysis, string proteolyisisProductName)
+        {
+            bool sequenceContainsNterminus = (fullProteinOneBasedBegin == 1);
+
+            //remove N-terminal methionine if appropriate and reset proteinOneBasedBegin
+            if (sequenceContainsNterminus && !retainNterminalMethionine && BaseSequence.Substring(fullProteinOneBasedBegin - 1, 1) == "M")
+            {
+                fullProteinOneBasedBegin++;
+            }
+
+            //Digest C-terminus
+            if (addCterminalDigestionBiomarkers)
+            {
+                for (int i = 1; i <= lengthOfProteolysis; i++)
+                {
+                    int newEnd = fullProteinOneBasedEnd - i;
+                    int length = newEnd - fullProteinOneBasedBegin + 1;
+                    if(length >= minProductBaseSequenceLength)
+                    {
+                        _proteolysisProducts.Add(new ProteolysisProduct(fullProteinOneBasedBegin, newEnd, proteolyisisProductName));
+                    }
+                }                
+            }
+
+            //Digest N-terminus
+            if (addNterminalDigestionBiomarkers)
+            {
+                for (int i = 1; i <= lengthOfProteolysis; i++)
+                {
+                    int newBegin = fullProteinOneBasedBegin + i;
+                    int length = fullProteinOneBasedEnd - newBegin + 1;
+                    if(length >= minProductBaseSequenceLength)
+                    {
+                        _proteolysisProducts.Add(new ProteolysisProduct(newBegin, fullProteinOneBasedEnd, proteolyisisProductName));
+                    }
+                }
+            }
+        }
+
+        public void AddBiomarkers(bool addFullProtein, bool addForEachProteolysisProduct, bool addNterminalDigestionBiomarkers, bool addCterminalDigestionBiomarkers, bool retainNterminalMethionine, int minProductBaseSequenceLength, int lengthOfProteolysis, string proteolyisisProductName)
+        {
+            if (addFullProtein)
+            {
+                AddBiomarkersToProteolysisProducts(1, BaseSequence.Length, addNterminalDigestionBiomarkers, addCterminalDigestionBiomarkers, retainNterminalMethionine, minProductBaseSequenceLength, lengthOfProteolysis, proteolyisisProductName);
+            }
+
+            if (addForEachProteolysisProduct)
+            {
+                List<ProteolysisProduct> existingProducts = ProteolysisProducts.Where(p => p.Type != "biomarker").ToList();
+                foreach (ProteolysisProduct product in existingProducts)
+                {
+                    if(product.OneBasedBeginPosition.HasValue && product.OneBasedEndPosition.HasValue)
+                    {
+                        AddBiomarkersToProteolysisProducts(product.OneBasedBeginPosition.Value, product.OneBasedEndPosition.Value, addNterminalDigestionBiomarkers, addCterminalDigestionBiomarkers, retainNterminalMethionine, minProductBaseSequenceLength, lengthOfProteolysis, proteolyisisProductName);
+                    }
+                }
+            }
         }
 
         private static string GetName(IEnumerable<SequenceVariation> appliedVariations, string name)

--- a/Proteomics/ProteolyticDigestion/proteases.tsv
+++ b/Proteomics/ProteolyticDigestion/proteases.tsv
@@ -3,7 +3,7 @@ Arg-C	R|			full	MS:1001303	Arg-C	(?<=R)(?!P)
 Asp-N	|D			full	MS:1001304	Asp-N	(?=[BD])		
 chymotrypsin (don't cleave before proline)	"F[P]|,W[P]|,Y[P]|"			full	MS:1001306	Chymotrypsin	(?<=[FYWL])(?!P)		
 chymotrypsin (cleave before proline)	"F|,W|,Y|"			full	MS:1001306	Chymotrypsin	(?<=[FYWL])		
-CNBr	M|			full	MS:1001307	CNBr	(?<=M)	Homoserine lactone on M
+CNBr	M|			full	MS:1001307	CNBr	(?<=M)	Homoserine lactone on M	
 elastase	"A|,V|,S|,G|,L|,I|"			full		Elastase	(?<=[AVSGLI])		
 Glu-C	E|			full					
 Glu-C (with asp)	"E|,D|"			full					
@@ -15,11 +15,11 @@ trypsin	"K|,R|"			full	MS:1001313	Trypsin/P	(?<=[KR])
 tryptophan oxidation	W|			full					
 non-specific	X|			full	MS:1001956	unspecific cleavage			
 top-down				none	MS:1001955	no cleavage			
+top-down biomarker				semi	MS:1001955	terminal cleavage			
 singleN				SingleN	MS:1001957	single cleavage			
 singleC				SingleC	MS:1001958	single cleavage			
 peptidomics				none		no cleavage			
 collagenase	GPX|GPX			full					
 StcE-trypsin	"TX|T,TX|S,SX|T,SX|S,K|,R|"			full		StcE/Trpsin			
 CNBr_old	M|			full	MS:1001307	CNBr	(?<=M)		
-CNBr_N	|M			full	MS:1001307	CNBr	(?<=M)	Test on M
-
+CNBr_N	|M			full	MS:1001307	CNBr	(?<=M)	Test on M	

--- a/Test/DataFiles/humanInsulin.xml
+++ b/Test/DataFiles/humanInsulin.xml
@@ -1,0 +1,377 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<uniprot xmlns="http://uniprot.org/uniprot" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://uniprot.org/uniprot http://www.uniprot.org/support/docs/uniprot.xsd">
+<entry dataset="Swiss-Prot" created="1986-07-21" modified="2021-09-29" version="262">
+<accession>P01308</accession>
+<accession>Q5EEX2</accession>
+<name>INS_HUMAN</name>
+<protein>
+<recommendedName>
+<fullName>Insulin</fullName>
+</recommendedName>
+<component>
+<recommendedName>
+<fullName>Insulin B chain</fullName>
+</recommendedName>
+</component>
+<component>
+<recommendedName>
+<fullName>Insulin A chain</fullName>
+</recommendedName>
+</component>
+</protein>
+<gene>
+<name type="primary">INS</name>
+</gene>
+<organism>
+<name type="scientific">Homo sapiens</name>
+<name type="common">Human</name>
+<dbReference type="NCBI Taxonomy" id="9606"/>
+<lineage>
+<taxon>Eukaryota</taxon>
+<taxon>Metazoa</taxon>
+<taxon>Chordata</taxon>
+<taxon>Craniata</taxon>
+<taxon>Vertebrata</taxon>
+<taxon>Euteleostomi</taxon>
+<taxon>Mammalia</taxon>
+<taxon>Eutheria</taxon>
+<taxon>Euarchontoglires</taxon>
+<taxon>Primates</taxon>
+<taxon>Haplorrhini</taxon>
+<taxon>Catarrhini</taxon>
+<taxon>Hominidae</taxon>
+<taxon>Homo</taxon>
+</lineage>
+</organism>
+<proteinExistence type="evidence at protein level"/>
+<keyword id="KW-0002">3D-structure</keyword>
+<keyword id="KW-0025">Alternative splicing</keyword>
+<keyword id="KW-0119">Carbohydrate metabolism</keyword>
+<keyword id="KW-0165">Cleavage on pair of basic residues</keyword>
+<keyword id="KW-0219">Diabetes mellitus</keyword>
+<keyword id="KW-0903">Direct protein sequencing</keyword>
+<keyword id="KW-0225">Disease variant</keyword>
+<keyword id="KW-1015">Disulfide bond</keyword>
+<keyword id="KW-0313">Glucose metabolism</keyword>
+<keyword id="KW-0372">Hormone</keyword>
+<keyword id="KW-0582">Pharmaceutical</keyword>
+<keyword id="KW-1185">Reference proteome</keyword>
+<keyword id="KW-0964">Secreted</keyword>
+<keyword id="KW-0732">Signal</keyword>
+<feature type="signal peptide" evidence="2">
+<location>
+<begin position="1"/>
+<end position="24"/>
+</location>
+</feature>
+<feature type="peptide" description="Insulin B chain" id="PRO_0000015819">
+<location>
+<begin position="25"/>
+<end position="54"/>
+</location>
+</feature>
+<feature type="propeptide" description="C peptide" id="PRO_0000015820">
+<location>
+<begin position="57"/>
+<end position="87"/>
+</location>
+</feature>
+<feature type="peptide" description="Insulin A chain" id="PRO_0000015821">
+<location>
+<begin position="90"/>
+<end position="110"/>
+</location>
+</feature>
+<feature type="disulfide bond" description="Interchain (between B and A chains)" evidence="1 9 16 19 20 21 22 23 24">
+<location>
+<begin position="31"/>
+<end position="96"/>
+</location>
+</feature>
+<feature type="disulfide bond" description="Interchain (between B and A chains)" evidence="1 9 16 19 20 21 22 23 24">
+<location>
+<begin position="43"/>
+<end position="109"/>
+</location>
+</feature>
+<feature type="disulfide bond" evidence="1 9 13 16 17 19 20 21 22 23 24">
+<location>
+<begin position="95"/>
+<end position="100"/>
+</location>
+</feature>
+<feature type="sequence variant" description="In MODY10; dbSNP:rs121908278." id="VAR_063721" evidence="5">
+<original>R</original>
+<variation>C</variation>
+<location>
+<position position="6"/>
+</location>
+</feature>
+<feature type="sequence variant" description="In MODY10; dbSNP:rs121908259." id="VAR_063722" evidence="7">
+<original>R</original>
+<variation>H</variation>
+<location>
+<position position="6"/>
+</location>
+</feature>
+<feature type="sequence variant" description="In PNDM4; dbSNP:rs80356663." id="VAR_063723" evidence="4 5">
+<original>A</original>
+<variation>D</variation>
+<location>
+<position position="24"/>
+</location>
+</feature>
+<feature type="sequence variant" description="In PNDM4; dbSNP:rs121908272." id="VAR_063724" evidence="5">
+<original>H</original>
+<variation>D</variation>
+<location>
+<position position="29"/>
+</location>
+</feature>
+<feature type="sequence variant" description="In PNDM4; dbSNP:rs80356664." id="VAR_063725" evidence="4 5">
+<original>G</original>
+<variation>R</variation>
+<location>
+<position position="32"/>
+</location>
+</feature>
+<feature type="sequence variant" description="In PNDM4; dbSNP:rs80356664." id="VAR_063726" evidence="4 5">
+<original>G</original>
+<variation>S</variation>
+<location>
+<position position="32"/>
+</location>
+</feature>
+<feature type="sequence variant" description="In HPRI; Providence; dbSNP:rs121918101." id="VAR_003971" evidence="10">
+<original>H</original>
+<variation>D</variation>
+<location>
+<position position="34"/>
+</location>
+</feature>
+<feature type="sequence variant" description="In PNDM4; dbSNP:rs121908273." id="VAR_063727" evidence="5">
+<original>L</original>
+<variation>P</variation>
+<location>
+<position position="35"/>
+</location>
+</feature>
+<feature type="sequence variant" description="In PNDM4; dbSNP:rs80356666." id="VAR_063728" evidence="4 5">
+<original>C</original>
+<variation>G</variation>
+<location>
+<position position="43"/>
+</location>
+</feature>
+<feature type="sequence variant" description="In MODY10; reduces binding affinity to INSR; reduces biological activity; reduces folding properties; dbSNP:rs121908260." id="VAR_063729" evidence="6 7 9">
+<original>R</original>
+<variation>Q</variation>
+<location>
+<position position="46"/>
+</location>
+</feature>
+<feature type="sequence variant" description="In PNDM4; dbSNP:rs80356667." id="VAR_063730" evidence="4 5">
+<original>G</original>
+<variation>V</variation>
+<location>
+<position position="47"/>
+</location>
+</feature>
+<feature type="sequence variant" description="In PNDM4; dbSNP:rs80356668." id="VAR_063731" evidence="4 5">
+<original>F</original>
+<variation>C</variation>
+<location>
+<position position="48"/>
+</location>
+</feature>
+<feature type="sequence variant" description="Associated with diabetes mellitus type-II; Los-Angeles; dbSNP:rs80356668." id="VAR_003972" evidence="14 15 16">
+<original>F</original>
+<variation>S</variation>
+<location>
+<position position="48"/>
+</location>
+</feature>
+<feature type="sequence variant" description="In Chicago; dbSNP:rs148685531." id="VAR_003973" evidence="15">
+<original>F</original>
+<variation>L</variation>
+<location>
+<position position="49"/>
+</location>
+</feature>
+<feature type="sequence variant" description="In IDDM2; dbSNP:rs121908261." id="VAR_063732" evidence="6">
+<original>R</original>
+<variation>C</variation>
+<location>
+<position position="55"/>
+</location>
+</feature>
+<feature type="sequence variant" description="In dbSNP:rs121908279." id="VAR_063733" evidence="5">
+<original>L</original>
+<variation>M</variation>
+<location>
+<position position="68"/>
+</location>
+</feature>
+<feature type="sequence variant" description="In PNDM4; uncertain pathological significance; dbSNP:rs121908274." id="VAR_063734" evidence="5">
+<original>G</original>
+<variation>R</variation>
+<location>
+<position position="84"/>
+</location>
+</feature>
+<feature type="sequence variant" description="In PNDM4; dbSNP:rs80356669." id="VAR_063735" evidence="4 5">
+<original>R</original>
+<variation>C</variation>
+<location>
+<position position="89"/>
+</location>
+</feature>
+<feature type="sequence variant" description="In HPRI; impairs post-translational cleavage; dbSNP:rs28933985." id="VAR_003974" evidence="8 12">
+<original>R</original>
+<variation>H</variation>
+<location>
+<position position="89"/>
+</location>
+</feature>
+<feature type="sequence variant" description="In HPRI; Kyoto; dbSNP:rs28933985." id="VAR_003975" evidence="3">
+<original>R</original>
+<variation>L</variation>
+<location>
+<position position="89"/>
+</location>
+</feature>
+<feature type="sequence variant" description="In PNDM4; dbSNP:rs80356670." id="VAR_063736" evidence="4 5">
+<original>G</original>
+<variation>C</variation>
+<location>
+<position position="90"/>
+</location>
+</feature>
+<feature type="sequence variant" description="In Wakayama; dbSNP:rs121918102." id="VAR_003976" evidence="11">
+<original>V</original>
+<variation>L</variation>
+<location>
+<position position="92"/>
+</location>
+</feature>
+<feature type="sequence variant" description="In PNDM4; dbSNP:rs80356671." id="VAR_063737" evidence="5">
+<original>C</original>
+<variation>S</variation>
+<location>
+<position position="96"/>
+</location>
+</feature>
+<feature type="sequence variant" description="In PNDM4; dbSNP:rs80356671." id="VAR_063738" evidence="4 5">
+<original>C</original>
+<variation>Y</variation>
+<location>
+<position position="96"/>
+</location>
+</feature>
+<feature type="sequence variant" description="In PNDM4; dbSNP:rs121908276." id="VAR_063739" evidence="5">
+<original>S</original>
+<variation>C</variation>
+<location>
+<position position="101"/>
+</location>
+</feature>
+<feature type="sequence variant" description="In PNDM4; dbSNP:rs121908277." id="VAR_063740" evidence="5">
+<original>Y</original>
+<variation>C</variation>
+<location>
+<position position="103"/>
+</location>
+</feature>
+<feature type="sequence variant" description="In PNDM4; dbSNP:rs80356672." id="VAR_063741" evidence="4 5">
+<original>Y</original>
+<variation>C</variation>
+<location>
+<position position="108"/>
+</location>
+</feature>
+<feature type="strand" evidence="29">
+<location>
+<begin position="26"/>
+<end position="29"/>
+</location>
+</feature>
+<feature type="helix" evidence="28">
+<location>
+<begin position="33"/>
+<end position="43"/>
+</location>
+</feature>
+<feature type="helix" evidence="28">
+<location>
+<begin position="44"/>
+<end position="46"/>
+</location>
+</feature>
+<feature type="strand" evidence="28">
+<location>
+<begin position="48"/>
+<end position="50"/>
+</location>
+</feature>
+<feature type="strand" evidence="25">
+<location>
+<begin position="56"/>
+<end position="58"/>
+</location>
+</feature>
+<feature type="turn" evidence="27">
+<location>
+<begin position="59"/>
+<end position="66"/>
+</location>
+</feature>
+<feature type="strand" evidence="27">
+<location>
+<begin position="74"/>
+<end position="76"/>
+</location>
+</feature>
+<feature type="helix" evidence="27">
+<location>
+<begin position="79"/>
+<end position="81"/>
+</location>
+</feature>
+<feature type="turn" evidence="27">
+<location>
+<begin position="84"/>
+<end position="86"/>
+</location>
+</feature>
+<feature type="helix" evidence="28">
+<location>
+<begin position="91"/>
+<end position="97"/>
+</location>
+</feature>
+<feature type="strand" evidence="29">
+<location>
+<begin position="98"/>
+<end position="101"/>
+</location>
+</feature>
+<feature type="helix" evidence="28">
+<location>
+<begin position="102"/>
+<end position="106"/>
+</location>
+</feature>
+<feature type="turn" evidence="26">
+<location>
+<begin position="107"/>
+<end position="109"/>
+</location>
+</feature>
+<sequence length="110" mass="11981" checksum="C2C3B23B85E520E5" modified="1986-07-21" version="1" precursor="true">
+MALWMRLLPLLALLALWGPDPAAAFVNQHLCGSHLVEALYLVCGERGFFYTPKTRREAEDLQVGQVELGGGPGAGSLQPLALEGSLQKRGIVEQCCTSICSLYQLENYCN
+</sequence>
+</entry>
+<copyright>
+Copyrighted by the UniProt Consortium, see https://www.uniprot.org/terms Distributed under the Creative Commons Attribution (CC BY 4.0) License
+</copyright>
+</uniprot>

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -247,6 +247,9 @@
     <None Update="DataFiles\BinGenerationTest.mzML">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="DataFiles\humanInsulin.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="DataFiles\sliced_ethcd.mzML">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
* correct Within calculation

* update unit tests

* first correct top-down biomarker test

* remove unused test code

* quotable protease

* unquotable

* add full length proteoform proteolysis products for biomarker search with  unit tests

* new strategy for adding proteolysis products

* more complete biomarker addition

* works for protein.xml databases

* add unit test biomarkers with xml database

* clean up

* more clean up

* fix unit test

Co-authored-by: MICHAEL SHORTREED <mrshortreed@wisc.edu>